### PR TITLE
Change service name

### DIFF
--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -19,7 +19,7 @@ describe('GET /', () => {
       .get('/')
       .expect('Content-Type', /html/)
       .expect(res => {
-        expect(res.text).toContain('Check Rule 39 Mail')
+        expect(res.text).toContain('Check Rule 39 mail')
 
         const doc = new JSDOM(res.text).window.document
         const link = doc.querySelector('a[href="/scan-barcode"]')

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -16,7 +16,7 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
   app.set('view engine', 'njk')
 
   app.locals.asset_path = '/assets/'
-  app.locals.applicationName = 'Check Rule 39 Mail'
+  app.locals.applicationName = 'Check Rule 39 mail'
 
   // Cachebusting version string
   if (production) {


### PR DESCRIPTION
Super small tweak to the name of the service so that it matches the former app and the DPS tile