### PR TITLE
SLM-330 - get user details from manage users API instead of hmpps auth.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Install dependencies using `npm install`, ensuring you are using `node v18.x` an
 Create a `.env` which should override environment variables required to run locally:
 ```properties
 HMPPS_AUTH_URL=http://localhost:9090/auth
+HMPPS_MANAGE_USERS_API_URL=https://manage-users-api-dev.hmpps.service.justice.gov.uk
 TOKEN_VERIFICATION_API_URL=https://token-verification-api-dev.prison.service.justice.gov.uk
 TOKEN_VERIFICATION_ENABLED=false
 NODE_ENV=development

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 import { resetStubs } from './integration_tests/mockApis/wiremock'
 import auth from './integration_tests/mockApis/auth'
+import manageUsersApi from './integration_tests/mockApis/manageUsersApi'
 import tokenVerification from './integration_tests/mockApis/tokenVerification'
 import prisonRegister from './integration_tests/mockApis/sendLegalMail/prisonRegister'
 import barcode from './integration_tests/mockApis/sendLegalMail/barcode'
@@ -28,7 +29,7 @@ export default defineConfig({
         stubSignInWithRole_SLM_SCAN_BARCODE: () => auth.stubSignIn(['ROLE_SLM_SCAN_BARCODE']),
         stubSignInWithRole_SLM_ADMIN: () => auth.stubSignIn(['ROLE_SLM_ADMIN']),
 
-        stubAuthUser: auth.stubUser,
+        stubManageUser: manageUsersApi.stubManageUser,
         stubAuthPing: auth.stubPing,
         stubAuthToken: auth.stubToken,
         stubDpsComponentsFail: dpsComponents.stubDpsComponentsFail,

--- a/feature.env
+++ b/feature.env
@@ -1,5 +1,6 @@
 PORT=3007
 HMPPS_AUTH_URL=http://localhost:9091/auth
+MANAGE_USERS_API_URL=http://localhost:9091/manage-users-api
 TOKEN_VERIFICATION_API_URL=http://localhost:9091/verification
 TOKEN_VERIFICATION_ENABLED=true
 SEND_LEGAL_MAIL_API_URL=http://localhost:9091/send-legal-mail

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -9,6 +9,7 @@ generic-service:
   env:
     INGRESS_URL: "https://check-rule39-mail-dev.prison.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
+    MANAGE_USERS_API_URL: "https://manage-users-api-dev.hmpps.service.justice.gov.uk"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
     SEND_LEGAL_MAIL_API_URL: "https://send-legal-mail-api-dev.prison.service.justice.gov.uk"
     PRISON_REGISTER_API_URL: "https://prison-register-dev.hmpps.service.justice.gov.uk"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -9,6 +9,7 @@ generic-service:
   env:
     INGRESS_URL: "https://check-rule39-mail-preprod.prison.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
+    MANAGE_USERS_API_URL: "https://manage-users-api-preprod.hmpps.service.justice.gov.uk"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-preprod.prison.service.justice.gov.uk"
     SEND_LEGAL_MAIL_API_URL: "https://send-legal-mail-api-preprod.prison.service.justice.gov.uk"
     PRISON_REGISTER_API_URL: "https://prison-register-preprod.hmpps.service.justice.gov.uk"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -8,6 +8,7 @@ generic-service:
   env:
     INGRESS_URL: "https://check-rule39-mail.prison.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
+    MANAGE_USERS_API_URL: "https://manage-users-api.hmpps.service.justice.gov.uk"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api.prison.service.justice.gov.uk"
     SEND_LEGAL_MAIL_API_URL: "https://send-legal-mail-api.prison.service.justice.gov.uk"
     PRISON_REGISTER_API_URL: "https://prison-register.hmpps.service.justice.gov.uk"

--- a/integration_tests/e2e/login.cy.ts
+++ b/integration_tests/e2e/login.cy.ts
@@ -7,7 +7,7 @@ context('SignIn', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubDpsComponentsFail')
   })
 
@@ -61,7 +61,7 @@ context('SignIn', () => {
     cy.request('/').its('body').should('contain', 'Sign in')
 
     cy.task('stubVerifyToken', true)
-    cy.task('stubAuthUser', 'bobby brown')
+    cy.task('stubManageUser', 'bobby brown')
     cy.signIn()
 
     indexPage.fallbackHeaderUserName().contains('B. Brown')

--- a/integration_tests/e2e/mailroomJourneyE2e.cy.ts
+++ b/integration_tests/e2e/mailroomJourneyE2e.cy.ts
@@ -6,7 +6,7 @@ import ScanAnotherBarcodePage from '../pages/scan/scanAnotherBarcode'
 context('Mailroom Journey E2E', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubSignInWithRole_SLM_SCAN_BARCODE')
     cy.task('stubVerifyValidBarcode')
     cy.task('stubVerifyNotFoundBarcode')

--- a/integration_tests/index.cy.ts
+++ b/integration_tests/index.cy.ts
@@ -6,7 +6,7 @@ context('Index Page', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
   })
 
   it('DPS user with SLM_SCAN_BARCODE role does see tile', () => {

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -118,45 +118,6 @@ const token = (authorities: string[]) =>
     },
   })
 
-const stubUser = (name: string = 'John Smith') =>
-  stubFor({
-    request: {
-      method: 'GET',
-      urlPattern: '/auth/api/user/me',
-    },
-    response: {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      jsonBody: {
-        activeCaseLoadId: 'MDI',
-        authSource: 'nomis',
-        staffId: 231232,
-        userId: 231232,
-        username: 'USER1',
-        active: true,
-        name,
-        uuid: '5105a589-75b3-4ca0-9433-b96228c1c8f3',
-      },
-    },
-  })
-
-const stubUserRoles = () =>
-  stubFor({
-    request: {
-      method: 'GET',
-      urlPattern: '/auth/api/user/me/roles',
-    },
-    response: {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      jsonBody: [{ roleCode: 'SOME_USER_ROLE' }],
-    },
-  })
-
 export default {
   getSignInUrl,
   stubPing: (): Promise<[Response, Response]> => Promise.all([ping(), tokenVerification.stubTokenVerificationPing()]),
@@ -169,6 +130,5 @@ export default {
       token(authorities),
       tokenVerification.stubVerifyToken(true),
     ]),
-  stubUser: (name: string): Promise<[Response, Response]> => Promise.all([stubUser(name), stubUserRoles()]),
   stubToken: (): Promise<Response> => token([]),
 }

--- a/integration_tests/mockApis/manageUsersApi.ts
+++ b/integration_tests/mockApis/manageUsersApi.ts
@@ -1,0 +1,46 @@
+import { stubFor } from './wiremock'
+import { UserRole } from '../../server/data/manageUsersApiClient'
+
+const stubUser = (name: string = 'john smith') =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/manage-users-api/users/me',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: {
+        activeCaseLoadId: 'MDI',
+        authSource: 'nomis',
+        staffId: 231232,
+        userId: 231232,
+        username: 'USER1',
+        active: true,
+        name,
+        uuid: '5105a589-75b3-4ca0-9433-b96228c1c8f3',
+      },
+    },
+  })
+
+const stubUserRoles = (roles: UserRole[] = [{ roleCode: 'SOME_USER_ROLE' }]) =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/manage-users-api/users/me/roles',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: roles,
+    },
+  })
+
+export default {
+  stubManageUser: stubUser,
+  stubManageUserRoles: stubUserRoles,
+}

--- a/integration_tests/page-not-found.cy.ts
+++ b/integration_tests/page-not-found.cy.ts
@@ -8,7 +8,7 @@ context('404 Page Not Found', () => {
 
   describe('Mail Room user', () => {
     it(`should show the 'page not found' page when authenticated as a mail room user and navigating to a non existent url`, () => {
-      cy.task('stubAuthUser')
+      cy.task('stubManageUser')
       cy.task('stubSignInWithRole_SLM_SCAN_BARCODE')
       cy.signIn()
 

--- a/integration_tests/scan/manuallyEnterBarcode.cy.ts
+++ b/integration_tests/scan/manuallyEnterBarcode.cy.ts
@@ -6,7 +6,7 @@ import ScanBarcodeResultPage from '../pages/scan/scanBarcodeResult'
 context('Manual Barcode Entry Page', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubGetPrisonRegister')
   })
 

--- a/integration_tests/scan/scanBarcode.cy.ts
+++ b/integration_tests/scan/scanBarcode.cy.ts
@@ -6,7 +6,7 @@ import ScanBarcodeResultPage from '../pages/scan/scanBarcodeResult'
 context('Scan Barcode Page', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
     cy.task('stubGetPrisonRegister')
   })
 

--- a/integration_tests/scan/scanBarcodeResult.cy.ts
+++ b/integration_tests/scan/scanBarcodeResult.cy.ts
@@ -6,7 +6,7 @@ import ScanBarcodeResultPage from '../pages/scan/scanBarcodeResult'
 context('Scan Barcode Result Page', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubAuthUser')
+    cy.task('stubManageUser')
   })
 
   it('Logged in user with SLM_SCAN_BARCODE role cannot navigate directly to scan barcode result page', () => {

--- a/server/config.ts
+++ b/server/config.ts
@@ -60,6 +60,14 @@ export default {
       systemClientId: get('SYSTEM_CLIENT_ID', 'clientid', requiredInProduction),
       systemClientSecret: get('SYSTEM_CLIENT_SECRET', 'clientsecret', requiredInProduction),
     },
+    manageUsersApi: {
+      url: get('MANAGE_USERS_API_URL', 'http://localhost:9091', requiredInProduction),
+      timeout: {
+        response: Number(get('MANAGE_USERS_API_TIMEOUT_RESPONSE', 10000)),
+        deadline: Number(get('MANAGE_USERS_API_TIMEOUT_DEADLINE', 10000)),
+      },
+      agent: new AgentConfig(Number(get('MANAGE_USERS_API_TIMEOUT_RESPONSE', 10000))),
+    },
     tokenVerification: {
       url: get('TOKEN_VERIFICATION_API_URL', 'http://localhost:8100', requiredInProduction),
       timeout: {

--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -25,32 +25,6 @@ describe('hmppsAuthClient', () => {
     nock.cleanAll()
   })
 
-  describe('getUser', () => {
-    it('should return data from api', async () => {
-      const response = { data: 'data' }
-
-      fakeHmppsAuthApi
-        .get('/api/user/me')
-        .matchHeader('authorization', `Bearer ${token.access_token}`)
-        .reply(200, response)
-
-      const output = await hmppsAuthClient.getUser(token.access_token)
-      expect(output).toEqual(response)
-    })
-  })
-
-  describe('getUserRoles', () => {
-    it('should return data from api', async () => {
-      fakeHmppsAuthApi
-        .get('/api/user/me/roles')
-        .matchHeader('authorization', `Bearer ${token.access_token}`)
-        .reply(200, [{ roleCode: 'role1' }, { roleCode: 'role2' }])
-
-      const output = await hmppsAuthClient.getUserRoles(token.access_token)
-      expect(output).toEqual(['role1', 'role2'])
-    })
-  })
-
   describe('getSystemClientToken', () => {
     it('should instantiate the redis client', async () => {
       tokenStore.getToken.mockResolvedValue(token.access_token)

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -5,7 +5,6 @@ import type TokenStore from './tokenStore'
 import logger from '../../logger'
 import config from '../config'
 import generateOauthClientToken from '../authentication/clientCredentials'
-import RestClient from './restClient'
 
 const timeoutSpec = config.apis.hmppsAuth.timeout
 const hmppsAuthUrl = config.apis.hmppsAuth.url
@@ -31,38 +30,8 @@ function getSystemClientTokenFromHmppsAuth(username?: string): Promise<superagen
     .timeout(timeoutSpec)
 }
 
-export interface User {
-  active: boolean
-  name: string
-  activeCaseLoadId: string
-  authSource: string
-  staffId: number
-  userId: number
-  username: string
-  uuid: string
-}
-
-export interface UserRole {
-  roleCode: string
-}
-
 export default class HmppsAuthClient {
   constructor(private readonly tokenStore: TokenStore) {}
-
-  private static restClient(token: string): RestClient {
-    return new RestClient('HMPPS Auth Client', config.apis.hmppsAuth, token)
-  }
-
-  getUser(token: string): Promise<User> {
-    logger.info(`Getting user details: calling HMPPS Auth`)
-    return HmppsAuthClient.restClient(token).get({ path: '/api/user/me' }) as Promise<User>
-  }
-
-  getUserRoles(token: string): Promise<string[]> {
-    return HmppsAuthClient.restClient(token)
-      .get({ path: '/api/user/me/roles' })
-      .then(roles => (<UserRole[]>roles).map(role => role.roleCode))
-  }
 
   async getSystemClientToken(username?: string): Promise<string> {
     const key = username || '%ANONYMOUS%'

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -13,6 +13,7 @@ buildAppInsightsClient(applicationInfo)
 import HmppsAuthClient from './hmppsAuthClient'
 import { createRedisClient } from './redisClient'
 import TokenStore from './tokenStore'
+import ManageUsersApiClient from './manageUsersApiClient'
 
 type RestClientBuilder<T> = (token: string) => T
 const redisClient = createRedisClient()
@@ -21,6 +22,7 @@ export const dataAccess = () => ({
   applicationInfo,
   redisClient,
   hmppsAuthClient: new HmppsAuthClient(new TokenStore(redisClient)),
+  manageUsersApiClient: new ManageUsersApiClient(),
 })
 
 export type DataAccess = ReturnType<typeof dataAccess>

--- a/server/data/manageUsersApiClient.test.ts
+++ b/server/data/manageUsersApiClient.test.ts
@@ -1,0 +1,49 @@
+import nock from 'nock'
+
+import config from '../config'
+import ManageUsersApiClient from './manageUsersApiClient'
+
+jest.mock('./tokenStore')
+
+const token = { access_token: 'token-1', expires_in: 300 }
+
+describe('manageUsersApiClient', () => {
+  let fakeManageUsersApiClient: nock.Scope
+  let manageUsersApiClient: ManageUsersApiClient
+
+  beforeEach(() => {
+    fakeManageUsersApiClient = nock(config.apis.manageUsersApi.url)
+    manageUsersApiClient = new ManageUsersApiClient()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+    nock.cleanAll()
+  })
+
+  describe('getUser', () => {
+    it('should return data from api', async () => {
+      const response = { data: 'data' }
+
+      fakeManageUsersApiClient
+        .get('/users/me')
+        .matchHeader('authorization', `Bearer ${token.access_token}`)
+        .reply(200, response)
+
+      const output = await manageUsersApiClient.getUser(token.access_token)
+      expect(output).toEqual(response)
+    })
+  })
+
+  describe('getUserRoles', () => {
+    it('should return data from api', async () => {
+      fakeManageUsersApiClient
+        .get('/users/me/roles')
+        .matchHeader('authorization', `Bearer ${token.access_token}`)
+        .reply(200, [{ roleCode: 'role1' }, { roleCode: 'role2' }])
+
+      const output = await manageUsersApiClient.getUserRoles(token.access_token)
+      expect(output).toEqual(['role1', 'role2'])
+    })
+  })
+})

--- a/server/data/manageUsersApiClient.ts
+++ b/server/data/manageUsersApiClient.ts
@@ -1,0 +1,35 @@
+import logger from '../../logger'
+import config from '../config'
+import RestClient from './restClient'
+
+export interface User {
+  active: boolean
+  name: string
+  activeCaseLoadId: string
+  authSource: string
+  staffId: number
+  userId: number
+  username: string
+  uuid: string
+}
+
+export interface UserRole {
+  roleCode: string
+}
+
+export default class ManageUsersApiClient {
+  private static restClient(token: string): RestClient {
+    return new RestClient('Manage Users Api Client', config.apis.manageUsersApi, token)
+  }
+
+  getUser(token: string): Promise<User> {
+    logger.info('Getting user details: calling HMPPS Manage Users Api')
+    return ManageUsersApiClient.restClient(token).get<User>({ path: '/users/me' })
+  }
+
+  getUserRoles(token: string): Promise<string[]> {
+    return ManageUsersApiClient.restClient(token)
+      .get<UserRole[]>({ path: '/users/me/roles' })
+      .then(roles => roles.map(role => role.roleCode))
+  }
+}

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -11,9 +11,9 @@ import { buildAppInsightsClient } from '../utils/azureAppInsights'
 import SmokeTestStore from '../data/cache/SmokeTestStore'
 
 export const services = () => {
-  const { hmppsAuthClient, redisClient, applicationInfo } = dataAccess()
+  const { hmppsAuthClient, manageUsersApiClient, redisClient, applicationInfo } = dataAccess()
   const appInsightsTelemetryClient: TelemetryClient = buildAppInsightsClient(applicationInfo)
-  const userService = new UserService(hmppsAuthClient)
+  const userService = new UserService(manageUsersApiClient)
   const scanBarcodeService = new ScanBarcodeService(hmppsAuthClient)
   const prisonService = new PrisonService(
     new PrisonRegisterService(new PrisonRegisterStore(redisClient)),

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -1,28 +1,28 @@
 import UserService from './userService'
-import HmppsAuthClient, { User } from '../data/hmppsAuthClient'
+import ManageUsersApiClient, { type User } from '../data/manageUsersApiClient'
 
-jest.mock('../data/hmppsAuthClient')
+jest.mock('../data/manageUsersApiClient')
 
 const token = 'some token'
 
 describe('User service', () => {
-  let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
+  let manageUsersApiClient: jest.Mocked<ManageUsersApiClient>
   let userService: UserService
 
   describe('getUser', () => {
     beforeEach(() => {
-      hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-      userService = new UserService(hmppsAuthClient)
+      manageUsersApiClient = new ManageUsersApiClient() as jest.Mocked<ManageUsersApiClient>
+      userService = new UserService(manageUsersApiClient)
     })
     it('Retrieves and formats user name', async () => {
-      hmppsAuthClient.getUser.mockResolvedValue({ name: 'john smith' } as User)
+      manageUsersApiClient.getUser.mockResolvedValue({ name: 'john smith' } as User)
 
       const result = await userService.getUser(token)
 
       expect(result.displayName).toEqual('John Smith')
     })
     it('Propagates error', async () => {
-      hmppsAuthClient.getUser.mockRejectedValue(new Error('some error'))
+      manageUsersApiClient.getUser.mockRejectedValue(new Error('some error'))
 
       await expect(userService.getUser(token)).rejects.toEqual(new Error('some error'))
     })

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,5 +1,5 @@
 import { convertToTitleCase } from '../utils/utils'
-import type HmppsAuthClient from '../data/hmppsAuthClient'
+import ManageUsersApiClient from '../data/manageUsersApiClient'
 
 interface UserDetails {
   name: string
@@ -9,10 +9,10 @@ interface UserDetails {
 }
 
 export default class UserService {
-  constructor(private readonly hmppsAuthClient: HmppsAuthClient) {}
+  constructor(private readonly manageUsersApiClient: ManageUsersApiClient) {}
 
   async getUser(token: string): Promise<UserDetails> {
-    const user = await this.hmppsAuthClient.getUser(token)
+    const user = await this.manageUsersApiClient.getUser(token)
     return { ...user, displayName: convertToTitleCase(user.name) }
   }
 }


### PR DESCRIPTION
Changes  based on similar changes on the incentives project - https://github.com/ministryofjustice/hmpps-incentives-ui/pull/646