### PR TITLE
Revert "chore(deps): update all non major npm dependencies"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "@types/superagent": "^8.1.9",
         "@types/supertest": "^7.2.0",
         "audit-ci": "^7.1.0",
-        "axe-core": "^4.11.2",
+        "axe-core": "^4.11.1",
         "cheerio": "^1.2.0",
         "concurrently": "^9.2.1",
         "cookie-session": "^2.1.1",
@@ -72,7 +72,7 @@
         "husky": "^9.1.7",
         "jest": "^30.3.0",
         "jest-environment-jsdom": "^30.3.0",
-        "jest-html-reporter": "^4.4.0",
+        "jest-html-reporter": "^4.3.0",
         "jest-junit": "^16.0.0",
         "jsonwebtoken": "^9.0.3",
         "lint-staged": "^16.4.0",
@@ -4470,9 +4470,9 @@
       "license": "MIT"
     },
     "node_modules/axe-core": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.2.tgz",
-      "integrity": "sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -9529,9 +9529,9 @@
       }
     },
     "node_modules/jest-html-reporter": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/jest-html-reporter/-/jest-html-reporter-4.4.0.tgz",
-      "integrity": "sha512-8aC5pzPOgsbiPwlvE686Gt3ZkUGHpafHtS0ffhCmKqTYdNwnrNX1WpmF7lbb3+3/TvZ9+UlACM811abivu5SWw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/jest-html-reporter/-/jest-html-reporter-4.3.0.tgz",
+      "integrity": "sha512-lq4Zx35yc6Ehw513CXJ1ok3wUmkSiOImWcyLAmylfzrz7DAqtrhDF9V73F4qfstmGxlr8X0QrEjWsl/oqhf4sQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9547,7 +9547,8 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "jest": "19.x - 30.x"
+        "jest": "19.x - 30.x",
+        "typescript": "^3.7.x || ^4.3.x || ^5.x"
       }
     },
     "node_modules/jest-junit": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@types/superagent": "^8.1.9",
     "@types/supertest": "^7.2.0",
     "audit-ci": "^7.1.0",
-    "axe-core": "^4.11.2",
+    "axe-core": "^4.11.1",
     "cheerio": "^1.2.0",
     "concurrently": "^9.2.1",
     "cookie-session": "^2.1.1",
@@ -97,7 +97,7 @@
     "husky": "^9.1.7",
     "jest": "^30.3.0",
     "jest-environment-jsdom": "^30.3.0",
-    "jest-html-reporter": "^4.4.0",
+    "jest-html-reporter": "^4.3.0",
     "jest-junit": "^16.0.0",
     "jsonwebtoken": "^9.0.3",
     "lint-staged": "^16.4.0",
@@ -113,7 +113,7 @@
   "overrides": {
     "mocha": {
       "diff": "^8.0.4",
-      "serialize-javascript": "^7.0.5"
+      "serialize-javascript": "^7.0.4"
     }
   }
 }


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-send-legal-mail-staff-ui#277

Not sure why this is causing a smoke test fail.